### PR TITLE
GPT3.5 Resilience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1723,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -2300,6 +2355,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "colored",
+ "json5",
  "llama-rs",
  "num-traits",
  "rand",
@@ -2718,6 +2774,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unic-char-property"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tiktoken-rs = { version = "0.4.1", features = ["async-openai"] }
 llama-rs = { git = "https://github.com/rustformers/llama-rs" }
 rand = "0.8.5"
 textwrap = "0.16.0"
+json5 = "0.4.1"

--- a/src/auto/agents/employee.rs
+++ b/src/auto/agents/employee.rs
@@ -169,7 +169,7 @@ These are your commands: {cmds_short}");
         context.agents.employee.llm.message_history.push(Message::Assistant(raw));
         context.agents.employee.llm.message_history.push(Message::User(out));
         context.agents.employee.llm.message_history.push(Message::User(format!(
-            r#"Decide whether or not you are done. If done, use the 'finish' command. Otherwise, proceed onto your next command. Ensure your response is fully JSON."#
+            r#"Decide whether or not you are done. If done, use the 'finish' command. Otherwise, proceed onto your next command. Ensure your response is the exact JSON format, no plaintext."#
         )));
 
         let remaining_tokens = context.agents.employee.llm.get_tokens_remaining(

--- a/src/auto/agents/employee.rs
+++ b/src/auto/agents/employee.rs
@@ -123,7 +123,7 @@ Keep every field in that exact order.
     let employee = "Employee".blue();
 
     loop {
-        let thoughts = try_parse_json::<EmployeeThought>(&context.agents.employee.llm, 2, Some(400))?;
+        let thoughts = try_parse_json::<EmployeeThought>(&context.agents.employee.llm, 2, Some(1000))?;
         let ParsedResponse { data: thoughts, raw } = thoughts;
 
         println!();
@@ -176,9 +176,9 @@ These are your commands: {cmds_short}");
             &context.agents.employee.llm.get_messages()
         )?;
 
-        if remaining_tokens < 750 {
+        if remaining_tokens < 1250 {
             ask_for_findings(&mut context.agents.employee)?;
-            context.agents.employee.llm.crop_to_tokens_remaining(2500);
+            context.agents.employee.llm.crop_to_tokens_remaining(2800)?;
 
             let observations = get_observations(&mut context.agents.employee, task)?
                 .unwrap_or("None found.".to_string());

--- a/src/auto/agents/findings.rs
+++ b/src/auto/agents/findings.rs
@@ -13,10 +13,10 @@ pub struct FindingsReport {
 pub fn create_findings_prompt() -> String {
     format!(
 r#"First, create a list of concise points about your findings from the commands.
-
 Then, create a list of long-lasting changes that were executed (i.e. writing to a file, posting a tweet.) Use quotes when discussing specific details.
 
-Keep your findings list very brief.
+Keep your findings list and changes list very brief.
+Each finding and change should be one sentence.
 
 Respond in this exact format:
 
@@ -39,7 +39,7 @@ Ensure your response is fully valid JSON."#)
 pub fn ask_for_findings(agent: &mut AgentInfo) -> Result<FindingsReport, Box<dyn Error>> {
     agent.llm.message_history.push(Message::User(create_findings_prompt()));
 
-    let report = try_parse_json::<FindingsReport>(&agent.llm, 2, Some(300))?.data;
+    let report = try_parse_json::<FindingsReport>(&agent.llm, 2, Some(600))?.data;
 
     agent.llm.message_history.pop();
 

--- a/src/auto/agents/manager.rs
+++ b/src/auto/agents/manager.rs
@@ -151,9 +151,9 @@ Changes carried out:
             &context.agents.managers[layer].llm.get_messages()
         )?;
 
-        if remaining_tokens < 750 {
+        if remaining_tokens < 1250 {
             ask_for_findings(&mut context.agents.managers[layer])?;
-            context.agents.managers[layer].llm.crop_to_tokens_remaining(2500);
+            context.agents.managers[layer].llm.crop_to_tokens_remaining(2800)?;
 
             let observations = get_observations(&mut context.agents.managers[layer], task)?
                 .unwrap_or("None found.".to_string());

--- a/src/auto/agents/mod.rs
+++ b/src/auto/agents/mod.rs
@@ -1,3 +1,4 @@
 pub mod employee;
 pub mod findings;
 pub mod manager;
+pub mod processing;

--- a/src/auto/agents/processing.rs
+++ b/src/auto/agents/processing.rs
@@ -1,0 +1,17 @@
+pub fn find_text_between_braces(input: &str) -> Option<String> {
+    let start_index = match input.find('{') {
+        Some(index) => index,
+        None => return None, // No opening brace found
+    };
+
+    let end_index = match input.rfind('}') {
+        Some(index) => index,
+        None => return None, // No closing brace found
+    };
+
+    if start_index >= end_index {
+        return None; // Closing brace comes before opening brace or no text in between
+    }
+
+    Some(format!("{}{}{}", "{", &input[start_index + 1..end_index], "}"))
+}

--- a/src/auto/responses.rs
+++ b/src/auto/responses.rs
@@ -20,7 +20,7 @@ pub fn ask_for_responses(agent: &mut AgentInfo) -> Result<String, Box<dyn Error>
     agent.llm.message_history.push(Message::User(create_runner_prompt()));
 
     let response = agent.llm.model.get_response_sync(
-        &agent.llm.get_messages(), Some(300), None
+        &agent.llm.get_messages(), Some(1000), None
     )?;
 
     Ok(response)
@@ -38,6 +38,8 @@ Reply in this JSON format:
 {{
     "response": "..."
 }}
+
+Respond in that exact JSON format exactly.
 
 Provide a response as an assistant to the initial request in the above format.
 Make sure you include where you got the information from in your response, in parantheses."#)

--- a/src/plugins/browse/mod.rs
+++ b/src/plugins/browse/mod.rs
@@ -112,6 +112,8 @@ pub async fn browse_url(ctx: &mut CommandContext, args: Vec<ScriptValue>) -> Res
 
         ctx.agents.fast.llm.message_history.push(Message::User(chunk.to_string()));
 
+        ctx.agents.fast.llm.message_history.push(Message::User(summary_prompt.clone()));
+
         let response = ctx.agents.fast.llm.model.get_response(
             &ctx.agents.fast.llm.get_messages(),
             None,


### PR DESCRIPTION
`gpt-3.5-turbo` often struggles to stay within the JSON format that it's provided with. This is demonstrated by #15.

To address this, this pull request adds two features.

1. Parsing JSON is done by looking for JSON anywhere in the string.
2. We use JSON5 to parse.

To ensure these changes don't come at the cost of consistency, after finding the JSON, we reformat it with the strict JSON format and overwrite the Assistant response with the exact, strict format.