### PR TITLE
use headless Chrome to browse_url 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ config.yml
 
 # LLM files
 ggml-vicuna*
+
+# interal checking files for browse plugin headless mod
+src/plugins/browse/run_parse.rs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ggml-vicuna*
 
 # interal checking files for browse plugin headless mod
 src/plugins/browse/run_parse.rs
+dir.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "ascii-canvas"
@@ -135,6 +135,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,10 +179,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_generate_cdp"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f9020527994849d0dd91cca0552686b011ca1f580aab008a230ab83b4e48f6"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backoff"
@@ -324,12 +405,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-rs"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76ee391b03d35510d9fa917357c7f1855bd9a6659c95a1b392e33f49b3369bc"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c55d429bef56ac9172d25fecb85dc8068307d17acd74b377866b7a1ef25d3c8"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -401,6 +516,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "concolor-override"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +562,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -976,10 +1111,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10c6ae9f6fa26f4fb2ac16b528d138d971ead56141de489f8111e259b9df3c4a"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gobject-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "h2"
@@ -1026,6 +1217,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "headless_chrome"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d8dccdaca7e147349fd264fcfe2886eec19fd4b926e55161902adc5768d9d4"
+dependencies = [
+ "anyhow",
+ "auto_generate_cdp",
+ "base64 0.13.1",
+ "derive_builder",
+ "log",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tungstenite",
+ "url",
+ "which",
+ "winreg",
 ]
 
 [[package]]
@@ -1141,15 +1355,27 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.1",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1527,6 +1753,12 @@ dependencies = [
  "tendril",
  "xml5ever",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -1954,6 +2186,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
+name = "pin-project"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +2224,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "poppler"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4d5fb5148fbfe436811ca4de5e10176c4ae953f5592982a1c3e74a88e7c20e"
+dependencies = [
+ "cairo-rs",
+ "glib",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2246,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,10 +2289,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
+
+[[package]]
+name = "qdrant-client"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c9a71bddf03a076a51c0b2fa48941a902ddb3a4525e1fafbdb1be0d31af5d6"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "prost",
+ "prost-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tonic",
+]
 
 [[package]]
 name = "quote"
@@ -2071,6 +2415,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "serde",
+ "serde_json",
+ "sha1_smol",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,9 +2490,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2148,7 +2514,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.1",
  "rustls-native-certs",
  "rustls-pemfile",
  "serde",
@@ -2250,6 +2616,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,6 +2646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2436,6 +2824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2867,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -2507,14 +2910,20 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 name = "smartgpt"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-openai",
  "async-recursion",
  "async-trait",
+ "base64 0.13.1",
  "colored",
+ "headless_chrome",
  "json5",
  "llm",
  "num-traits",
+ "poppler",
+ "qdrant-client",
  "rand",
+ "redis",
  "regex",
  "reqwest",
  "rustpython-parser",
@@ -2526,6 +2935,8 @@ dependencies = [
  "tiktoken-rs",
  "tokenizers",
  "tokio",
+ "tonic",
+ "url",
 ]
 
 [[package]]
@@ -2540,6 +2951,17 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
  "libc",
  "winapi",
 ]
@@ -2629,6 +3051,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-deps"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fa6fb9ee296c0dc2df41a656ca7948546d061958115ddb0bcaae43ad0d17d2"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +3079,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "tempfile"
@@ -2815,6 +3262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,13 +3294,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls",
+ "rustls 0.21.1",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -2870,6 +3326,98 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -2914,6 +3462,25 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "twox-hash"
@@ -3081,6 +3648,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64 0.13.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.20.8",
+ "socks",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3692,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "version_check"
@@ -3228,6 +3818,26 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -3398,6 +4008,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "smartgpt"
 version = "0.1.0"
 edition = "2021"
 
+# [[bin]]
+# name = "run_parse"
+# path = "src/plugins/browse/run_parse.rs"
+
+
 [dependencies]
 async-openai = "0.10.2"
 async-recursion = "1.0.4"
@@ -13,7 +18,7 @@ regex = "1.7.3"
 reqwest = "0.11.16"
 rustpython-parser = "0.2.0"
 select = "0.6.0"
-serde = { version = "1.0.159", features = [ "derive" ] }
+serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 serde_yaml = "0.9.21"
 tokenizers = "0.13.3"
@@ -32,3 +37,5 @@ base64 = "0.13"
 headless_chrome = "1.0.5"
 poppler = "0.3.2"
 url = "2.3"
+# article_scraper = "2.0.0-alpha.0"
+# html2text = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ qdrant-client = "1.1.2"
 anyhow = "1.0.71"
 tonic = "0.9.2"
 base64 = "0.13"
+
+headless_chrome = "1.0.5"
+poppler = "0.3.2"
+url = "2.3"

--- a/src/auto/agents/employee.rs
+++ b/src/auto/agents/employee.rs
@@ -124,7 +124,7 @@ Keep every field in that exact order.
     let employee = "Employee".blue();
 
     loop {
-        let thoughts = try_parse_json::<EmployeeThought>(&context.agents.employee.llm, 2, Some(1000))?;
+        let thoughts = try_parse_json::<EmployeeThought>(&context.agents.employee.llm, 2, Some(400))?;
         let ParsedResponse { data: thoughts, raw } = thoughts;
 
         println!();

--- a/src/plugins/browse/headless/mod.rs
+++ b/src/plugins/browse/headless/mod.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+use std::{path::PathBuf, process::exit};
+
+use anyhow::Result;
+// use article_scraper::{
+//     ArticleScraper, FtrConfigEntry, FullTextParser,
+//     Readability::{self},
+// };
+use headless_chrome::{
+    protocol::cdp::Page::CaptureScreenshotFormatOption, types::PrintToPdfOptions, Browser,
+    LaunchOptions,
+};
+use poppler::PopplerDocument;
+use poppler::PopplerPage;
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use std::fs;
+use tokio::sync::mpsc::{self, Sender};
+use url::Url;
+
+pub async fn get_content_headless(url: &str) -> anyhow::Result<String> {
+    let options = LaunchOptions {
+        headless: true,
+        window_size: Some((1200, 1920)),
+        ..Default::default()
+    };
+
+    let browser = Browser::new(options)?;
+
+    // let url = "https://github.com/Cormanz/smartgpt";
+    // let url = "https://github.com/Cormanz/smartgpt/tree/main/src";
+
+    let tab = browser.new_tab()?;
+    tab.set_default_timeout(std::time::Duration::from_secs(10));
+    tab.navigate_to(url)?;
+
+    let html = tab.get_content()?;
+
+    let parsed_url = Url::parse(&url)?;
+    let base_url = format!(
+        "{}://{}",
+        parsed_url.scheme(),
+        parsed_url.host_str().unwrap()
+    );
+    // let base_url = Url::parse("https://github.com/").unwrap();
+
+    let pdf_options: Option<PrintToPdfOptions> = Some(PrintToPdfOptions {
+        landscape: Some(false),
+        display_header_footer: Some(false),
+        print_background: Some(false),
+        scale: Some(0.5),
+        paper_width: Some(11.0),
+        paper_height: Some(17.0),
+        margin_top: Some(0.1),
+        margin_bottom: Some(0.1),
+        margin_left: Some(0.1),
+        margin_right: Some(0.1),
+        page_ranges: Some("1-2".to_string()),
+        ignore_invalid_page_ranges: Some(true),
+        prefer_css_page_size: Some(false),
+        transfer_mode: None,
+        ..Default::default()
+    });
+
+    let pdf_data = tab.print_to_pdf(pdf_options)?;
+
+    // fs::write("github.pdf", pdf_data.clone())?;
+
+    let mut pdf_as_vec = pdf_data.to_vec();
+
+    let doc = PopplerDocument::new_from_data(&mut pdf_as_vec, "")?;
+
+    let page = doc.get_page(0).unwrap();
+    match page.get_text() {
+        Some(content) => Ok(content.to_string()),
+        None => Err(anyhow::anyhow!("failed to parse pdf to text")),
+    }
+
+    // println!("page {:?}", content);
+
+    // fs::write("raw.github.html", html.clone())?;
+
+    // println!("{:?}", extracted_content.);
+    // let bytes = std::fs::read("new-ithub.pdf")?;
+    // let out = pdf_extract::extract_text_from_mem(&bytes)?;
+}

--- a/src/plugins/browse/headless/mod.rs
+++ b/src/plugins/browse/headless/mod.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
-use std::{path::PathBuf, process::exit};
+// use std::path::Path;
+// use std::{path::PathBuf, process::exit};
 
 use anyhow::Result;
 // use article_scraper::{
@@ -10,15 +10,20 @@ use headless_chrome::{
     protocol::cdp::Page::CaptureScreenshotFormatOption, types::PrintToPdfOptions, Browser,
     LaunchOptions,
 };
+// use html2text::from_read;
 use poppler::PopplerDocument;
 use poppler::PopplerPage;
-use reqwest::header::HeaderMap;
-use reqwest::Client;
-use std::fs;
-use tokio::sync::mpsc::{self, Sender};
+// use std::fs::{write, File};
+// use std::io::{self, BufReader};
+// use tokio::sync::mpsc::{self, Sender};
 use url::Url;
 
+// this webpage parsing method relies on poppler-rs, a library for rendering PDF files
+// Warning: poppler depends on libpoppler, which has only been tested on Linux
+// ensure that libpoppler-glib is installed to use it.
 pub async fn get_content_headless(url: &str) -> anyhow::Result<String> {
+    // set the headless Chrome to open a webpage in portrait mode of certain width and height
+    // could possibly lower the likelyhood of loading unwanted/lower priority elements
     let options = LaunchOptions {
         headless: true,
         window_size: Some((1200, 1920)),
@@ -27,23 +32,45 @@ pub async fn get_content_headless(url: &str) -> anyhow::Result<String> {
 
     let browser = Browser::new(options)?;
 
-    // let url = "https://github.com/Cormanz/smartgpt";
-    // let url = "https://github.com/Cormanz/smartgpt/tree/main/src";
+    // let mut text_from_readability_parsing = String::new();
+    let mut text_from_pdf_conversion = String::new();
 
     let tab = browser.new_tab()?;
-    tab.set_default_timeout(std::time::Duration::from_secs(10));
+
+    // giving the browser 5 seconds to load a page
+    tab.set_default_timeout(std::time::Duration::from_secs(5));
     tab.navigate_to(url)?;
 
     let html = tab.get_content()?;
 
     let parsed_url = Url::parse(&url)?;
-    let base_url = format!(
-        "{}://{}",
-        parsed_url.scheme(),
-        parsed_url.host_str().unwrap()
-    );
+    let host_str = parsed_url.host_str().unwrap_or("");
+    let base_url = format!("{}://{}", parsed_url.scheme(), host_str);
+    let base_url = Url::parse(&base_url)?;
     // let base_url = Url::parse("https://github.com/").unwrap();
+    // let raw_file_name = format!("output/raw.{host_str}.html");
+    // let clean_file_name = format!("output/clean.{host_str}.html");
+    // write(&raw_file_name, html.clone())?;
 
+    // match Readability::extract(&html, Some(base_url)).await {
+    //     Ok(res) => {
+    //         // println!("{:?}", res.to_string());
+    //         text_from_readability_parsing = from_read(res.to_string().as_bytes(), 80);
+    //         println!("{:?}", text_from_readability_parsing.to_string());
+    //     }
+    //     Err(_err) => {}
+    // };
+
+    // match std::fs::write(PathBuf::from(&clean_file_name), result.clone()) {
+    //     Ok(()) => {println!("{:?}", result.clone());
+    // return Ok(result);}
+    //     Err(err) => {
+    //        exit(0);
+    //     }
+    // }
+
+    // print the webpage to a long paper virtually, shrink the print scale, hoping to get
+    // important information in this single page
     let pdf_options: Option<PrintToPdfOptions> = Some(PrintToPdfOptions {
         landscape: Some(false),
         display_header_footer: Some(false),
@@ -64,23 +91,29 @@ pub async fn get_content_headless(url: &str) -> anyhow::Result<String> {
 
     let pdf_data = tab.print_to_pdf(pdf_options)?;
 
-    // fs::write("github.pdf", pdf_data.clone())?;
+    // // fs::write("github.pdf", pdf_data.clone())?;
 
     let mut pdf_as_vec = pdf_data.to_vec();
 
+    // parse captured webpage in pdf format, with "", which means no password
     let doc = PopplerDocument::new_from_data(&mut pdf_as_vec, "")?;
+    // println!("----------------------");
 
-    let page = doc.get_page(0).unwrap();
-    match page.get_text() {
-        Some(content) => Ok(content.to_string()),
-        None => Err(anyhow::anyhow!("failed to parse pdf to text")),
-    }
+    // work with the one and only page, obtain the text data
+    if let Some(page) = doc.get_page(0) {
+        if let Some(content) = page.get_text() {
+            text_from_pdf_conversion = content.to_string();
+            // println!("{:?}", text_from_pdf_conversion.to_string());
+        }
+    };
+    Ok(text_from_pdf_conversion)
 
-    // println!("page {:?}", content);
-
-    // fs::write("raw.github.html", html.clone())?;
-
-    // println!("{:?}", extracted_content.);
-    // let bytes = std::fs::read("new-ithub.pdf")?;
-    // let out = pdf_extract::extract_text_from_mem(&bytes)?;
+    // if text_from_readability_parsing.split_whitespace().count() > 300 {
+    //     // Ok(text_from_readability_parsing)
+    //     Ok(text_from_pdf_conversion)
+    // } else {
+    //     // Ok(text_from_pdf_conversion)
+    //     Ok(text_from_readability_parsing)
+    // }
+    // None => Err(anyhow::anyhow!("failed to parse pdf to text")),
 }

--- a/src/plugins/browse/mod.rs
+++ b/src/plugins/browse/mod.rs
@@ -113,7 +113,7 @@ pub async fn browse_url(
     // )
     // .await?;
 
-    let content = headless::get_content_headless(&url).await.unwrap();
+    let content = headless::get_content_headless(&url).await?;
 
     // let content = extract_text_from_html(&body);
 

--- a/src/plugins/browse/mod.rs
+++ b/src/plugins/browse/mod.rs
@@ -1,25 +1,32 @@
-use std::{error::Error, fmt::Display};
 use async_trait::async_trait;
 use colored::Colorize;
-use reqwest::{Client, header::{USER_AGENT, HeaderMap}};
+use reqwest::{
+    header::{HeaderMap, USER_AGENT},
+    Client,
+};
+use std::{error::Error, fmt::Display};
 use textwrap::wrap;
 
 mod extract;
+mod headless;
 
 pub use extract::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{Plugin, Command, CommandContext, CommandImpl, PluginData, PluginDataNoInvoke, PluginCycle, invoke, ScriptValue, CommandArgument, Message};
+use crate::{
+    invoke, Command, CommandArgument, CommandContext, CommandImpl, Message, Plugin, PluginCycle,
+    PluginData, PluginDataNoInvoke, ScriptValue,
+};
 
 pub struct BrowseData {
-    pub client: Client
+    pub client: Client,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct BrowseRequest {
     pub url: String,
-    pub params: Vec<(String, String)>
+    pub params: Vec<(String, String)>,
 }
 
 #[async_trait]
@@ -30,19 +37,20 @@ impl PluginData for BrowseData {
                 let BrowseRequest { url, params } = serde_json::from_value(value)?;
                 let res_result = self.client.get(url).query(&params).send().await?;
                 let text = res_result.text().await?;
-                
+
                 Ok(text.into())
             }
-            _ => {
-                Err(Box::new(PluginDataNoInvoke("Browse".to_string(), name.to_string())))
-            }
+            _ => Err(Box::new(PluginDataNoInvoke(
+                "Browse".to_string(),
+                name.to_string(),
+            ))),
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DownloadTextResults {
-    text: String
+    text: String,
 }
 
 #[derive(Debug, Clone)]
@@ -50,7 +58,11 @@ pub struct BrowseNoArgError;
 
 impl Display for BrowseNoArgError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", "'browse-article' command did not receive one of its arguments.")
+        write!(
+            f,
+            "{}",
+            "'browse-article' command did not receive one of its arguments."
+        )
     }
 }
 
@@ -59,7 +71,7 @@ impl Error for BrowseNoArgError {}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NoContentError {
     error: String,
-    help: String
+    help: String,
 }
 
 fn chunk_text(text: &str, chunk_size: usize) -> Vec<String> {
@@ -79,20 +91,31 @@ fn chunk_text(text: &str, chunk_size: usize) -> Vec<String> {
     chunks
 }
 
-pub async fn browse_url(ctx: &mut CommandContext, args: Vec<ScriptValue>) -> Result<ScriptValue, Box<dyn Error>> {
+pub async fn browse_url(
+    ctx: &mut CommandContext,
+    args: Vec<ScriptValue>,
+) -> Result<ScriptValue, Box<dyn Error>> {
     let browse_info = ctx.plugin_data.get_data("Browse")?;
 
     let params: [(&str, &str); 0] = [];
-    let url: String = args.get(0).ok_or(BrowseNoArgError)?.clone().try_into()?;   
+    let url: String = args.get(0).ok_or(BrowseNoArgError)?.clone().try_into()?;
 
-    let body = invoke::<String>(browse_info, "browse", BrowseRequest {
-        url: url.to_string(),
-        params: params.iter()
-            .map(|el| (el.0.to_string(), el.1.to_string()))
-            .collect::<Vec<_>>()
-    }).await?;
+    // let body = invoke::<String>(
+    //     browse_info,
+    //     "browse",
+    //     BrowseRequest {
+    //         url: url.to_string(),
+    //         params: params
+    //             .iter()
+    //             .map(|el| (el.0.to_string(), el.1.to_string()))
+    //             .collect::<Vec<_>>(),
+    //     },
+    // )
+    // .await?;
 
-    let content = extract_text_from_html(&body);
+    let content = headless::get_content_headless(&url).await.unwrap();
+
+    // let content = extract_text_from_html(&body);
 
     let mut summarized_content = String::new();
     let chunks = chunk_text(&content, 11000);
@@ -100,25 +123,45 @@ pub async fn browse_url(ctx: &mut CommandContext, args: Vec<ScriptValue>) -> Res
     let chunk_count = chunks.len();
     let summary_prompt = match chunk_count {
         0..=2 => "Create a paragraph summary.",
-        _ => "Create a two-sentence summary."
-    }.to_string();
+        _ => "Create a two-sentence summary.",
+    }
+    .to_string();
 
     for (ind, chunk) in chunks.iter().enumerate() {
-        println!("{} {} / {}", "Summarizing Chunk".green(), ind + 1, chunks.len());
+        println!(
+            "{} {} / {}",
+            "Summarizing Chunk".green(),
+            ind + 1,
+            chunks.len()
+        );
 
         ctx.agents.fast.llm.message_history.clear();
 
-        ctx.agents.fast.llm.message_history.push(Message::System(summary_prompt.clone()));
+        ctx.agents
+            .fast
+            .llm
+            .message_history
+            .push(Message::System(summary_prompt.clone()));
 
-        ctx.agents.fast.llm.message_history.push(Message::User(chunk.to_string()));
+        ctx.agents
+            .fast
+            .llm
+            .message_history
+            .push(Message::User(chunk.to_string()));
 
-        ctx.agents.fast.llm.message_history.push(Message::User(summary_prompt.clone()));
+        ctx.agents
+            .fast
+            .llm
+            .message_history
+            .push(Message::User(summary_prompt.clone()));
 
-        let response = ctx.agents.fast.llm.model.get_response(
-            &ctx.agents.fast.llm.get_messages(),
-            None,
-            None
-        ).await?;
+        let response = ctx
+            .agents
+            .fast
+            .llm
+            .model
+            .get_response(&ctx.agents.fast.llm.get_messages(), None, None)
+            .await?;
 
         summarized_content.push_str(&response);
     }
@@ -130,7 +173,11 @@ pub struct BrowseURL;
 
 #[async_trait]
 impl CommandImpl for BrowseURL {
-    async fn invoke(&self, ctx: &mut CommandContext, args: Vec<ScriptValue>) -> Result<ScriptValue, Box<dyn Error>> {
+    async fn invoke(
+        &self,
+        ctx: &mut CommandContext,
+        args: Vec<ScriptValue>,
+    ) -> Result<ScriptValue, Box<dyn Error>> {
         browse_url(ctx, args).await
     }
 
@@ -143,21 +190,24 @@ pub struct BrowseCycle;
 
 #[async_trait]
 impl PluginCycle for BrowseCycle {
-    async fn create_context(&self, _context: &mut CommandContext, _previous_prompt: Option<&str>) -> Result<Option<String>, Box<dyn Error>> {
+    async fn create_context(
+        &self,
+        _context: &mut CommandContext,
+        _previous_prompt: Option<&str>,
+    ) -> Result<Option<String>, Box<dyn Error>> {
         Ok(None)
     }
 
     fn create_data(&self, _: Value) -> Option<Box<dyn PluginData>> {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, "SmartGPT v0.0.1".parse().unwrap());
-    
+
         let client = reqwest::Client::builder()
             .default_headers(headers)
-            .build().unwrap();
+            .build()
+            .unwrap();
 
-        Some(Box::new(BrowseData {
-            client
-        }))
+        Some(Box::new(BrowseData { client }))
     }
 }
 
@@ -166,16 +216,12 @@ pub fn create_browse() -> Plugin {
         name: "Browse".to_string(),
         dependencies: vec![],
         cycle: Box::new(BrowseCycle),
-        commands: vec![
-            Command {
-                name: "browse_url".to_string(),
-                purpose: "Browse the paragraph-only content from an exact URL.".to_string(),
-                args: vec![
-                    CommandArgument::new("url", "The URL to browse.", "String")
-                ],
-                return_type: "String".to_string(),
-                run: Box::new(BrowseURL)
-            }
-        ]
+        commands: vec![Command {
+            name: "browse_url".to_string(),
+            purpose: "Browse the paragraph-only content from an exact URL.".to_string(),
+            args: vec![CommandArgument::new("url", "The URL to browse.", "String")],
+            return_type: "String".to_string(),
+            run: Box::new(BrowseURL),
+        }],
     }
 }


### PR DESCRIPTION
- headless Chrome to allow js and make it possible to properly "read" much of today's webpages
- capture webpage in pdf format virtually, aiming to get what human eyes see
- use poppler-rs library to get text content from the "pdf file" in memory
note: poppler-rs currently tested to work on Linux only