### PR TITLE
Fix NewsAPI not loading, make Updates serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartgpt"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartgpt"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "A crate that provides LLMs with the ability to complete complex tasks using plugins."

--- a/src/api/config/mod.rs
+++ b/src/api/config/mod.rs
@@ -80,7 +80,8 @@ pub fn list_plugins() -> Vec<Plugin> {
         create_google(),
         create_filesystem(),
         create_wolfram(),
-        create_brainstorm()
+        create_brainstorm(),
+        create_news()
     ]
 }
 

--- a/src/auto/agents/worker/updates.rs
+++ b/src/auto/agents/worker/updates.rs
@@ -1,26 +1,35 @@
+use serde::{Deserialize, Serialize};
+
 use super::{BrainThoughts, MethodicalPlan, MethodicalThoughts, MethodicalStep, Memories};
 
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct NamedAsset(pub String, pub String);
 
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum DynamicUpdate {
     Plan(String),
     Thoughts(BrainThoughts)
 }
 
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum StaticUpdate {
+    #[serde(rename = "plan")]
     Plan(MethodicalPlan),
+    #[serde(rename = "selected step")]
     SelectedStep(MethodicalStep),
+    #[serde(rename = "thoughts")]
     Thoughts(MethodicalThoughts),
+    #[serde(rename = "action results")]
     ActionResults(String),
+    #[serde(rename = "added asset")]
     AddedAsset(NamedAsset),
     SavedMemories(Memories)
 }
 
-#[derive(Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Update {
+    #[serde(rename = "dynamic agent")]
     DynamicAgent(DynamicUpdate),
+    #[serde(rename = "static agent")]
     StaticAgent(StaticUpdate)
 }


### PR DESCRIPTION
- Fixes the NewsAPI plugin not being registered in the plugins list, so it can now be used.
- Makes Updates serializable for easy prototyping and debugging.