### PR TITLE
Update API to use `FnMut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartgpt"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartgpt"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "A crate that provides LLMs with the ability to complete complex tasks using plugins."

--- a/src/api/smartgpt.rs
+++ b/src/api/smartgpt.rs
@@ -47,8 +47,8 @@ impl SmartGPT {
     pub fn run_task(
         &mut self,
         task: &str,
-        allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-        listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+        allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+        listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
     ) -> Result<String, Box<dyn Error>> {
         run_auto(self, task, allow_action, listen_to_update)
     }

--- a/src/auto/agents/worker/adept.rs
+++ b/src/auto/agents/worker/adept.rs
@@ -65,8 +65,8 @@ pub fn get_response(
     get_planner_agent: &impl Fn(&mut CommandContext) -> &mut AgentInfo,
     thoughts: &BrainThoughts,
     personality: &str,
-    allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<String, Box<dyn Error>> {
     match thoughts.decision.decision_type.deref() {
         "spawn_agent" => {
@@ -105,8 +105,8 @@ pub fn run_brain_agent(
     get_agent: &impl Fn(&mut CommandContext) -> &mut AgentInfo,
     task: &str,
     personality: &str,
-    allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<String, Box<dyn Error>> {
     let agent = get_agent(context);
     

--- a/src/auto/agents/worker/methodical.rs
+++ b/src/auto/agents/worker/methodical.rs
@@ -67,7 +67,7 @@ pub struct Memories {
 
 pub fn add_memories(
     agent: &mut AgentInfo,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<(), Box<dyn Error>> {
     agent.llm.message_history.push(Message::User(
         SUMMARIZE_MEMORIES.fill(NoData)?  
@@ -91,8 +91,8 @@ pub fn run_method_agent(
     desire: &str,
     assets: Option<String>,
     personality: &str,
-    allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<String, Box<dyn Error>> {
     let tools: Vec<&Tool> = context.plugins.iter()
         .flat_map(|plugin| &plugin.tools)

--- a/src/auto/agents/worker/mod.rs
+++ b/src/auto/agents/worker/mod.rs
@@ -18,8 +18,8 @@ pub fn run_worker(
     smartgpt: &mut SmartGPT, 
     task: &str, 
     personality: &str,
-    allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<String, Box<dyn Error>> {
     let mut context = smartgpt.context.lock().unwrap();
 

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -32,8 +32,8 @@ impl Display for DisallowedAction {
 pub fn run_auto(
     smartgpt: &mut SmartGPT, 
     task: &str,
-    allow_action: &impl Fn(&Action) -> Result<(), DisallowedAction>,
-    listen_to_update: &impl Fn(&Update) -> Result<(), Box<dyn Error>>
+    allow_action: &mut impl FnMut(&Action) -> Result<(), DisallowedAction>,
+    listen_to_update: &mut impl FnMut(&Update) -> Result<(), Box<dyn Error>>
 ) -> Result<String, Box<dyn Error>> {
     let SmartGPT { 
         context, ..

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     smartgpt.run_task( 
         &task, 
-        &|_| Ok(()), 
-        &log_update
+        &mut |_| Ok(()), 
+        &mut log_update
     )?;
 
     Ok(())


### PR DESCRIPTION
This is a general quality of life change for use of SmartGPT as a crate, allowing for `allow_action` and `listen_to_update` to modify their outside environment.