### PR TITLE
Use Tabs over Spaces for Faster JSON Tokenization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartgpt"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartgpt"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 description = "A crate that provides LLMs with the ability to complete complex tasks using plugins."

--- a/src/auto/agents/prompt/adept.rs
+++ b/src/auto/agents/prompt/adept.rs
@@ -26,7 +26,7 @@ Remember that you have access to external tools, so you can do any task.
 Respond in this JSON format:
 ```json
 {{
-    "concise plan on how you will complete the task": "plan"
+	"concise plan on how you will complete the task": "plan"
 }}
 ```
 "#, PhantomData);
@@ -62,12 +62,12 @@ Only include one `thoughts`, `reasoning`, `decision`.
 Respond in this exact JSON format exactly, with every field in order:
 ```json
 {{
-    "thoughts": "thoughts",
-    "reasoning": "reasoning",
-    "decision": {{
-        "type": "decision type",
-        "args": "..."
-    }}
+	"thoughts": "thoughts",
+	"reasoning": "reasoning",
+	"decision": {{
+		"type": "decision type",
+		"args": "..."
+	}}
 }}
 ```
 "#, PhantomData);
@@ -92,12 +92,12 @@ You may only provide these assets when spawning agents.
 
 ```json
 {{
-    "thoughts": "thoughts",
-    "reasoning": "reasoning",
-    "decision": {{
-        "type": "decision type",
-        "args": "..."
-    }}
+	"thoughts": "thoughts",
+	"reasoning": "reasoning",
+	"decision": {{
+		"type": "decision type",
+		"args": "..."
+	}}
 }}  
 ```
 "#, PhantomData);

--- a/src/auto/agents/prompt/methodical.rs
+++ b/src/auto/agents/prompt/methodical.rs
@@ -68,33 +68,33 @@ After you are done planning steps, additionally plan to save one or more assets 
 Respond in this JSON format:
 ```json
 {{
-    "thoughts": "thoughts regarding steps and assets",
-    "steps": [
-        {{
-            "idea": "idea",
-            "decision": {{
-                "resource": {{
-                    "name": "name",
-                    "question": "what question does using this resource answer"
-                }}
-            }}
-        }},
-        {{
-            "idea": "idea",
-            "decision": {{
-                "action": {{
-                    "name": "name",
-                    "purpose": "why use this action"
-                }}
-            }}
-        }}
-    ],
-    "assets": [
-        {{
-            "name": "asset_name,
-            "description": "description"
-        }}
-    ]
+	"thoughts": "thoughts regarding steps and assets",
+	"steps": [
+		{{
+			"idea": "idea",
+			"decision": {{
+				"resource": {{
+					"name": "name",
+					"question": "what question does using this resource answer"
+				}}
+			}}
+		}},
+		{{
+			"idea": "idea",
+			"decision": {{
+				"action": {{
+					"name": "name",
+					"purpose": "why use this action"
+				}}
+			}}
+		}}
+	],
+	"assets": [
+		{{
+			"name": "asset_name,
+			"description": "description"
+		}}
+	]
 }}
 ```
 "#, PhantomData);
@@ -119,11 +119,11 @@ No assets.
 Respond in this JSON format:
 ```json
 {{
-    "thoughts": "thoughts",
-    "action": {{
-        "tool": "tool",
-        "args": {{}}
-    }}
+	"thoughts": "thoughts",
+	"action": {{
+		"tool": "tool",
+		"args": {{}}
+	}}
 }}
 ```
 "#, PhantomData);


### PR DESCRIPTION
- Replaces all instances of `    ` (four spaces; up to four tokens) with `	` (tab token; usually only one token)
- Updates to `v0.1.6`