### PR TITLE
Fix Prompt Bug, Browse Tokenizing, Selected Asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smartgpt"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smartgpt"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 license = "MIT"
 description = "A crate that provides LLMs with the ability to complete complex tasks using plugins."

--- a/src/auto/agents/prompt/methodical.rs
+++ b/src/auto/agents/prompt/methodical.rs
@@ -16,12 +16,12 @@ Be concise.
 Respond in this JSON format:
 ```json
 {{
-    "actions": [
-        "what tool you used and why"
-    ],
-    "observations": [
-        "what you learned"
-    ]
+	"actions": [
+		"what tool you used and why"
+	],
+	"observations": [
+		"what you learned"
+	]
 }}
 ```"#, PhantomData);
 

--- a/src/auto/agents/prompt/mod.rs
+++ b/src/auto/agents/prompt/mod.rs
@@ -11,8 +11,14 @@ pub struct Prompt<'a, T : Serialize>(pub &'a str, pub PhantomData<T>);
 
 impl<'a, T : Serialize> Prompt<'a, T> {
     pub fn fill(&self, data: T) -> Result<String, Box<dyn Error>> {
-        let items: HashMap<String, String> = serde_json::from_value(serde_json::to_value(data)?)?;
         let mut out = self.0.trim().to_string();
+
+        let items: HashMap<String, String> = match serde_json::from_value(serde_json::to_value(data)?) {
+            Ok(items) => items,
+            Err(_) => {
+                return Ok(out);
+            }
+        };
 
         for (key, value) in items {
             out = out.replace(&format!("[{key}]"), &value);

--- a/src/auto/agents/worker/methodical.rs
+++ b/src/auto/agents/worker/methodical.rs
@@ -206,6 +206,8 @@ pub fn run_method_agent(
     let mut changed_assets: Vec<NamedAsset> = vec![];
 
     for asset in plan.assets {
+        listen_to_update(&Update::StaticAgent(StaticUpdate::SelectedAsset(asset.name.clone())))?;
+
         let agent = get_agent(context);
 
         let asset_text = serde_yaml::to_string(&asset)?;
@@ -227,8 +229,9 @@ pub fn run_method_agent(
         changed_assets.push(named_asset.clone());
         listen_to_update(&Update::StaticAgent(StaticUpdate::AddedAsset(named_asset.clone())))?;
     }
-    
+
     let agent = get_agent(context);
+
     add_memories(agent, listen_to_update)?;
 
     let asset_str = if changed_assets.len() == 0 {

--- a/src/auto/agents/worker/updates.rs
+++ b/src/auto/agents/worker/updates.rs
@@ -23,6 +23,8 @@ pub enum StaticUpdate {
     Thoughts(MethodicalThoughts),
     #[serde(rename = "action results")]
     ActionResults(String),
+    #[serde(rename = "selected asset")]
+    SelectedAsset(String),
     #[serde(rename = "added asset")]
     AddedAsset(NamedAsset),
     #[serde(rename = "added memories")]

--- a/src/llms/chatgpt.rs
+++ b/src/llms/chatgpt.rs
@@ -4,7 +4,7 @@ use async_openai::{Client, types::{CreateChatCompletionResponse, CreateChatCompl
 use async_trait::async_trait;
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
-use tiktoken_rs::{async_openai::{get_chat_completion_max_tokens, num_tokens_from_messages}, model::get_context_size};
+use tiktoken_rs::{async_openai::{get_chat_completion_max_tokens, num_tokens_from_messages}, model::get_context_size, cl100k_base, r50k_base};
 
 use crate::{LLMProvider, Message, LLMModel};
 
@@ -67,6 +67,15 @@ impl LLMModel for ChatGPT {
             .collect::<Vec<_>>();
 
         let tokens = get_chat_completion_max_tokens(&self.model, &messages)?;
+        Ok(tokens)
+    }
+
+    fn get_tokens_from_text(&self, text: &str) -> Result<Vec<String>, Box<dyn Error>> {
+        let bpe = r50k_base()?;
+        let tokens = bpe.encode_ordinary(text).iter()
+            .flat_map(|&token| bpe.decode(vec![ token ]))
+            .collect::<Vec<_>>();
+
         Ok(tokens)
     }
 }

--- a/src/llms/local.rs
+++ b/src/llms/local.rs
@@ -71,6 +71,10 @@ impl LLMModel for LocalLLM {
     fn get_token_limit(&self) -> usize {
         2048
     }
+
+    fn get_tokens_from_text(&self, text: &str) -> Result<Vec<String>, Box<dyn Error>> {
+        return Ok(vec![])
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/llms/mod.rs
+++ b/src/llms/mod.rs
@@ -105,6 +105,8 @@ pub trait LLMModel : Send + Sync {
             self.get_base_embed(text).await
         })
     }
+
+    fn get_tokens_from_text(&self, text: &str) -> Result<Vec<String>, Box<dyn Error>>;
 }
 
 #[async_trait]
@@ -151,6 +153,10 @@ impl LLM {
         }
 
         Ok(())
+    }
+
+    pub fn get_tokens_from_text(&self, text: &str) -> Result<Vec<String>, Box<dyn Error>> {
+        self.model.get_tokens_from_text(text)
     }
 
     pub fn get_messages(&self) -> Vec<Message> {

--- a/src/log.rs
+++ b/src/log.rs
@@ -47,6 +47,12 @@ pub fn log_update(update: &Update) -> Result<(), Box<dyn Error>> {
                     println!("{out}");
                     println!();
                 },
+                StaticUpdate::SelectedAsset(asset) => {
+                    println!("{} | {}", "Static Agent".yellow().bold(), "Selected Asset".white());
+                    println!();
+                    println!("{asset}");
+                    println!();
+                },
                 StaticUpdate::AddedAsset(asset) => {
                     println!("{} | {}", "Static Agent".yellow().bold(), "Added Asset".white());
                     println!();


### PR DESCRIPTION
- Fixes a bug with `Prompt` where the program stops when trying to save memories due to a failed parsing into a `HashMap`
- Adds a tokenization API to LLMs, allows for `browse_urls` to summarize in larger chunks
- Adds a new Selected Asset update type.