### PR TITLE
fix: prevent token-budget underflow on oversized contexts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - fix/token-budget-underflow
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Run locked test suite
+        run: cargo test --locked

--- a/src/llms/mod.rs
+++ b/src/llms/mod.rs
@@ -90,7 +90,9 @@ pub trait LLMModel : Send + Sync {
     fn get_token_limit(&self) -> usize;
 
     fn get_tokens_remaining(&self, text: &[Message]) -> Result<usize, Box<dyn Error>> {
-        Ok(self.get_token_limit() - self.get_token_count(text)?)
+        Ok(self
+            .get_token_limit()
+            .saturating_sub(self.get_token_count(text)?))
     }
 
     fn get_response_sync(&self, messages: &[Message], max_tokens: Option<u16>, temperature: Option<f32>) -> Result<String, Box<dyn Error>> {
@@ -199,4 +201,76 @@ pub fn format_prompt(messages: &[Message]) -> String {
     out.push_str("ASSISTANT: ");
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FixedTokenModel {
+        token_limit: usize,
+        tokens_per_message: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMModel for FixedTokenModel {
+        async fn get_response(
+            &self,
+            _messages: &[Message],
+            _max_tokens: Option<u16>,
+            _temperature: Option<f32>,
+        ) -> Result<String, Box<dyn Error>> {
+            Ok(String::new())
+        }
+
+        async fn get_base_embed(&self, _text: &str) -> Result<Vec<f32>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+
+        fn get_token_count(&self, messages: &[Message]) -> Result<usize, Box<dyn Error>> {
+            Ok(messages.len() * self.tokens_per_message)
+        }
+
+        fn get_token_limit(&self) -> usize {
+            self.token_limit
+        }
+
+        fn get_tokens_from_text(&self, _text: &str) -> Result<Vec<String>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn token_budget_saturates_when_context_exceeds_limit() {
+        let model = FixedTokenModel {
+            token_limit: 10,
+            tokens_per_message: 6,
+        };
+        let messages = vec![
+            Message::User("first".to_string()),
+            Message::Assistant("second".to_string()),
+        ];
+
+        assert_eq!(model.get_tokens_remaining(&messages).unwrap(), 0);
+    }
+
+    #[test]
+    fn crop_removes_history_until_requested_budget_is_available() {
+        let model = FixedTokenModel {
+            token_limit: 30,
+            tokens_per_message: 10,
+        };
+        let mut llm = LLM::new(Box::new(model));
+        llm.prompt.push(Message::System("system".to_string()));
+        llm.message_history = vec![
+            Message::User("first".to_string()),
+            Message::Assistant("second".to_string()),
+            Message::User("third".to_string()),
+        ];
+
+        llm.crop_to_tokens_remaining(10).unwrap();
+
+        assert_eq!(llm.message_history.len(), 1);
+        assert_eq!(llm.get_tokens_remaining(&llm.get_messages()).unwrap(), 10);
+    }
 }


### PR DESCRIPTION
## Problem

The default `LLMModel::get_tokens_remaining` implementation subtracts the measured context size directly from the model limit using `usize`:

```rust
limit - used
```

When a local or custom provider reports a context larger than its limit, this underflows. In debug/test builds it panics before `crop_to_tokens_remaining` can remove old history; in optimized builds it can wrap to a very large budget and skip cropping entirely.

The OpenAI provider overrides this method, so this specifically protects the default contract used by local and future custom providers.

## Change

- use `saturating_sub` so an exhausted/oversized context reports zero remaining tokens
- add a provider-independent mock-model regression test for the oversized case
- add a crop regression test proving history is removed until the requested budget is restored
- add a minimal, read-only GitHub Actions workflow running `cargo test --locked`
- pin `actions/checkout` to the full v7.0.1 commit SHA

## Verification

Fork CI passed twice. The final run uses the current checkout action and has no Node runtime deprecation warning:

- `cargo test --locked`: passed
- run: https://github.com/lindixu6-hash/smartgpt/actions/runs/32040485878
- commit: `095e1cd698c2a0c5944256b35d962c5aea96e897`

No provider network calls or API keys are used by the new tests.
